### PR TITLE
BB-900: save card_image_url in the correct model when loading data

### DIFF
--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -218,7 +218,6 @@ class CoursesApiDataLoader(AbstractDataLoader):
         if not self.partner.has_marketing_site:
             defaults.update({
                 'start': self.parse_date(body['start']),
-                'card_image_url': body['media'].get('image', {}).get('raw'),
                 'title_override': body['name'],
                 'short_description_override': body['short_description'],
                 'video': self.get_courserun_video(body),
@@ -236,6 +235,12 @@ class CoursesApiDataLoader(AbstractDataLoader):
         defaults = {
             'title': body['name'],
         }
+
+        # When using a marketing site, only dates (excluding start) should come from the Course API.
+        if not self.partner.has_marketing_site:
+            defaults.update({
+                'card_image_url': body['media'].get('image', {}).get('raw'),
+            })
 
         return defaults
 

--- a/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/tests/test_api.py
@@ -196,7 +196,7 @@ class CoursesApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCas
         if not partner_has_marketing_site:
             expected_values.update({
                 'start': self.loader.parse_date(body['start']),
-                'card_image_url': body['media'].get('image', {}).get('raw'),
+                'card_image_url': None,
                 'title_override': body['name'],
                 'short_description_override': self.loader.clean_string(body['short_description']),
                 'video': self.loader.get_courserun_video(body),
@@ -204,6 +204,9 @@ class CoursesApiDataLoaderTests(ApiClientTestMixin, DataLoaderTestMixin, TestCas
                 'pacing_type': self.loader.get_pacing_type(body),
                 'mobile_available': body['mobile_available'] or False,
             })
+
+            # Check if the course card_image_url was correctly updated
+            self.assertEqual(course.card_image_url, body['media'].get('image', {}).get('raw'),)
 
         for field, value in expected_values.items():
             self.assertEqual(getattr(course_run, field), value, 'Field {} is invalid.'.format(field))


### PR DESCRIPTION
This PR fixes a small bug on the discovery service where the data loader would incorrectly save `card_image_url` to the incorrect model, resulting in courses with missing course images on services that use the discovery service (e.g. ecommerce).

**Testing instructions:**
1. Checkout this branch on your devstack
2. Log into the course discovery shell with `make discovery-shell` and updated the course metadata:
```
./manage.py refresh_course_metadata
```
3. Go to http://localhost:18130/basket/add/?sku=8CF08E5 and check that the course image is being correctly displayed.
![its_there_now](https://user-images.githubusercontent.com/27893385/53113467-69b1db00-3520-11e9-9e3b-fbe8c44efd47.png)

**Reviewers:**
- [ ] @kaizoku 