### PR TITLE
fix: fallback to 'price' in ecommerce api loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         continue-on-error: ${{ matrix.status == 'ignored' }}
       - name: Upload coverage
         if: matrix.db-version == 'mysql80'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage${{ matrix.pytest-split-group }}
           path: .coverage

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -572,7 +572,10 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     def update_seat(self, course_run, product_body):
         stock_record = product_body['stockrecords'][0]
         currency_code = stock_record['price_currency']
-        price = Decimal(stock_record['price_excl_tax'])
+        if 'price_excl_tax' in stock_record:
+            price = Decimal(stock_record['price_excl_tax'])
+        else:
+            price = Decimal(stock_record['price'])
         sku = stock_record['partner_sku']
 
         # For more context see ADR docs/decisions/0025-dont-sync-mobile-skus-on-discovery.rst

--- a/course_discovery/apps/course_metadata/data_loaders/api.py
+++ b/course_discovery/apps/course_metadata/data_loaders/api.py
@@ -572,10 +572,7 @@ class EcommerceApiDataLoader(AbstractDataLoader):
     def update_seat(self, course_run, product_body):
         stock_record = product_body['stockrecords'][0]
         currency_code = stock_record['price_currency']
-        if 'price_excl_tax' in stock_record:
-            price = Decimal(stock_record['price_excl_tax'])
-        else:
-            price = Decimal(stock_record['price'])
+        price = Decimal(stock_record.get('price_excl_tax', stock_record['price']))
         sku = stock_record['partner_sku']
 
         # For more context see ADR docs/decisions/0025-dont-sync-mobile-skus-on-discovery.rst


### PR DESCRIPTION
## Description

The Django Oscar upgrade of ecommerce changed the
item's price field from `price_excl_tax` to just `price`
causing the EcommerceApi data loader to fail.

This commit handled the exception and falls back to
the 'price' value.

Ref: https://github.com/openedx/ecommerce/pull/4050

## Additional information

The same as #4291.

## Testing instructions

### Reproduce Issue

1. Setup Tutor 18 (Redwood) dev env with the plugins `ecommerce` and `discovery` enabled
2. Clone course-discovery.
3. Add a tutor mount for the course-discovery.
4. Create a course or import the demo course.
5. Setup admin user for ecommerce and discovery
6. Add a course seat in http://ecommerce.local.edly.io:8130/courses/ for the test course
7. Run the following from Discovery Shell to set the ecommerce API url. NOTE: trying the same in Discovery admin fails due to URL validation.
    ```
    from course_discovery.apps.core.models import Partner
    p = Partner.objects.get(short_code="dev")
    p.ecommerce_api_url = "http://ecommerce:8130/api/v2/"
    p.save()
    ```
8. Run `./manage.py refresh_course_metadata --partner dev`. It should fail with the KeyError `price_excl_tax`.

### Testing the fix from PR

1. Checkout the PR branch
2. Run `./manage.py refresh_course_metadata --partner dev` again. This time, it should run successfully.